### PR TITLE
:sparkles: 파이어베이스 회원가입/로그인 추가

### DIFF
--- a/Vincent.xcodeproj/project.pbxproj
+++ b/Vincent.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		10DAAE4D28F539B1000CB45C /* ArtItemCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */; };
+		10DAAE4F28F539C1000CB45C /* ArtItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewCell.swift */; };
+		10DAAE5128F539CA000CB45C /* ArtItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5028F539CA000CB45C /* ArtItem.swift */; };
+		10DAAE5328F5C792000CB45C /* ArtItemCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5228F5C792000CB45C /* ArtItemCategoryView.swift */; };
+		10DAAE5528F5C7C2000CB45C /* ArtItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5428F5C7C2000CB45C /* ArtItemViewController.swift */; };
+		10DAAE5728F5D480000CB45C /* ArtItemCategoryViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5628F5D480000CB45C /* ArtItemCategoryViewCell.swift */; };
 		58161E9328F43DF0001F8461 /* SellCheckBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58161E9228F43DF0001F8461 /* SellCheckBoxView.swift */; };
 		5826B99828F2A51000F60693 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826B99728F2A51000F60693 /* UIFont+Extension.swift */; };
 		5855709828F2AEDF002FB7C9 /* SellTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5855709728F2AEDF002FB7C9 /* SellTextFieldView.swift */; };
@@ -24,17 +30,12 @@
 		A9D7B9DE28F27B4D00ECEF58 /* ItemTappedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D7B9DD28F27B4D00ECEF58 /* ItemTappedViewController.swift */; };
 		A9F068C828F52E36009B5CEE /* ProfileEnumeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F068C728F52E36009B5CEE /* ProfileEnumeration.swift */; };
 		CB18F2D928F67D5400742C30 /* GoodInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB18F2D828F67D5400742C30 /* GoodInfoView.swift */; };
-
-
-		10DAAE4D28F539B1000CB45C /* ArtItemCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4C28F539B1000CB45C /* ArtItemCollectionViewController.swift */; };
-		10DAAE4F28F539C1000CB45C /* ArtItemCollectionViewcellController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewcellController.swift */; };
-		10DAAE4D28F539B1000CB45C /* ArtItemCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */; };
-		10DAAE4F28F539C1000CB45C /* ArtItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewCell.swift */; };
-		10DAAE5128F539CA000CB45C /* ArtItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5028F539CA000CB45C /* ArtItem.swift */; };
-		10DAAE5328F5C792000CB45C /* ArtItemCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5228F5C792000CB45C /* ArtItemCategoryView.swift */; };
-		10DAAE5528F5C7C2000CB45C /* ArtItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5428F5C7C2000CB45C /* ArtItemViewController.swift */; };
-		10DAAE5728F5D480000CB45C /* ArtItemCategoryViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5628F5D480000CB45C /* ArtItemCategoryViewCell.swift */; };
-
+		CB4DE21628F8EE1E004B23AA /* Sequence+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4DE21528F8EE1E004B23AA /* Sequence+Extension.swift */; };
+		CB4DE21828F8EF4F004B23AA /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4DE21728F8EF4F004B23AA /* User.swift */; };
+		CB76B9EA28F8EAF700B35811 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB76B9E928F8EAF700B35811 /* SignUpViewController.swift */; };
+		CB76B9EC28F8EB0400B35811 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB76B9EB28F8EB0400B35811 /* LoginViewController.swift */; };
+		CB76B9EE28F8EB7800B35811 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB76B9ED28F8EB7800B35811 /* FirebaseManager.swift */; };
+		CB76B9F028F8EB8C00B35811 /* PushNotificationSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB76B9EF28F8EB8C00B35811 /* PushNotificationSender.swift */; };
 		CB81DA5428F1B108005164FA /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = CB81DA5328F1B108005164FA /* Lottie */; };
 		CB81DA5728F1B15D005164FA /* MessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB81DA5628F1B15D005164FA /* MessageViewController.swift */; };
 		CB81DA5A28F1B19E005164FA /* SellViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB81DA5928F1B19E005164FA /* SellViewController.swift */; };
@@ -69,9 +70,22 @@
 		CBCBEF8A28F2E430009F134F /* MessageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBCBEF8928F2E430009F134F /* MessageTableViewCell.swift */; };
 		CBCBEF8E28F2E4A2009F134F /* MessageKit in Frameworks */ = {isa = PBXBuildFile; productRef = CBCBEF8D28F2E4A2009F134F /* MessageKit */; };
 		CBCBEF9028F2E570009F134F /* Sender.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBCBEF8F28F2E570009F134F /* Sender.swift */; };
+		CBF5ED3428F8F27D00580F77 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = CBF5ED3328F8F27D00580F77 /* FirebaseAuth */; };
+		CBF5ED3628F8F27D00580F77 /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = CBF5ED3528F8F27D00580F77 /* FirebaseDatabase */; };
+		CBF5ED3828F8F27D00580F77 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = CBF5ED3728F8F27D00580F77 /* FirebaseFirestore */; };
+		CBF5ED3A28F8F27D00580F77 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = CBF5ED3928F8F27D00580F77 /* FirebaseMessaging */; };
+		CBF5ED3C28F8F27D00580F77 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = CBF5ED3B28F8F27D00580F77 /* FirebaseStorage */; };
+		CBF5ED3E28F8F2AC00580F77 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CBF5ED3D28F8F2AC00580F77 /* FirebaseFirestoreSwift */; };
+		CBF5ED4028F8FA0F00580F77 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CBF5ED3F28F8FA0F00580F77 /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionView.swift; sourceTree = "<group>"; };
+		10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionViewCell.swift; sourceTree = "<group>"; };
+		10DAAE5028F539CA000CB45C /* ArtItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItem.swift; sourceTree = "<group>"; };
+		10DAAE5228F5C792000CB45C /* ArtItemCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCategoryView.swift; sourceTree = "<group>"; };
+		10DAAE5428F5C7C2000CB45C /* ArtItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemViewController.swift; sourceTree = "<group>"; };
+		10DAAE5628F5D480000CB45C /* ArtItemCategoryViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCategoryViewCell.swift; sourceTree = "<group>"; };
 		58161E9228F43DF0001F8461 /* SellCheckBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellCheckBoxView.swift; sourceTree = "<group>"; };
 		5826B99728F2A51000F60693 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		5855709728F2AEDF002FB7C9 /* SellTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellTextFieldView.swift; sourceTree = "<group>"; };
@@ -89,15 +103,12 @@
 		A9D7B9DD28F27B4D00ECEF58 /* ItemTappedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemTappedViewController.swift; sourceTree = "<group>"; };
 		A9F068C728F52E36009B5CEE /* ProfileEnumeration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEnumeration.swift; sourceTree = "<group>"; };
 		CB18F2D828F67D5400742C30 /* GoodInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoodInfoView.swift; sourceTree = "<group>"; };
-
-		10DAAE4C28F539B1000CB45C /* ArtItemCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionViewController.swift; sourceTree = "<group>"; };
-		10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewcellController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionViewcellController.swift; sourceTree = "<group>"; };
-		10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionView.swift; sourceTree = "<group>"; };
-		10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionViewCell.swift; sourceTree = "<group>"; };
-		10DAAE5028F539CA000CB45C /* ArtItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItem.swift; sourceTree = "<group>"; };
-		10DAAE5228F5C792000CB45C /* ArtItemCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCategoryView.swift; sourceTree = "<group>"; };
-		10DAAE5428F5C7C2000CB45C /* ArtItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemViewController.swift; sourceTree = "<group>"; };
-		10DAAE5628F5D480000CB45C /* ArtItemCategoryViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCategoryViewCell.swift; sourceTree = "<group>"; };
+		CB4DE21528F8EE1E004B23AA /* Sequence+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+Extension.swift"; sourceTree = "<group>"; };
+		CB4DE21728F8EF4F004B23AA /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		CB76B9E928F8EAF700B35811 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
+		CB76B9EB28F8EB0400B35811 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		CB76B9ED28F8EB7800B35811 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
+		CB76B9EF28F8EB8C00B35811 /* PushNotificationSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationSender.swift; sourceTree = "<group>"; };
 		CB81DA5628F1B15D005164FA /* MessageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageViewController.swift; sourceTree = "<group>"; };
 		CB81DA5928F1B19E005164FA /* SellViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellViewController.swift; sourceTree = "<group>"; };
 		CBADEE2A28EEBCE00010B5AA /* Vincent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Vincent.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -130,6 +141,7 @@
 		CBCBEF8728F2E40C009F134F /* MessageRoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRoomViewController.swift; sourceTree = "<group>"; };
 		CBCBEF8928F2E430009F134F /* MessageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageTableViewCell.swift; sourceTree = "<group>"; };
 		CBCBEF8F28F2E570009F134F /* Sender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sender.swift; sourceTree = "<group>"; };
+		CBF5ED3F28F8FA0F00580F77 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -137,16 +149,35 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CBF5ED3A28F8F27D00580F77 /* FirebaseMessaging in Frameworks */,
 				CBADEE7028EEC65B0010B5AA /* SnapKit in Frameworks */,
+				CBF5ED3428F8F27D00580F77 /* FirebaseAuth in Frameworks */,
+				CBF5ED3C28F8F27D00580F77 /* FirebaseStorage in Frameworks */,
 				CBADEE7328EEC6720010B5AA /* Then in Frameworks */,
+				CBF5ED3E28F8F2AC00580F77 /* FirebaseFirestoreSwift in Frameworks */,
 				CB81DA5428F1B108005164FA /* Lottie in Frameworks */,
 				CBCBEF8E28F2E4A2009F134F /* MessageKit in Frameworks */,
+				CBF5ED3828F8F27D00580F77 /* FirebaseFirestore in Frameworks */,
+				CBF5ED3628F8F27D00580F77 /* FirebaseDatabase in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		10DAAE4B28F5393C000CB45C /* ArtItem */ = {
+			isa = PBXGroup;
+			children = (
+				10DAAE5428F5C7C2000CB45C /* ArtItemViewController.swift */,
+				10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */,
+				10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewCell.swift */,
+				10DAAE5228F5C792000CB45C /* ArtItemCategoryView.swift */,
+				10DAAE5628F5D480000CB45C /* ArtItemCategoryViewCell.swift */,
+				10DAAE5028F539CA000CB45C /* ArtItem.swift */,
+			);
+			path = ArtItem;
+			sourceTree = "<group>";
+		};
 		7B5CB9D128F7B96B007DDEA2 /* Home */ = {
 			isa = PBXGroup;
 			children = (
@@ -192,17 +223,20 @@
 			path = UIComponent;
 			sourceTree = "<group>";
 		};
-		10DAAE4B28F5393C000CB45C /* ArtItem */ = {
+		CB76B9E728F8EAD300B35811 /* Login */ = {
 			isa = PBXGroup;
 			children = (
-				10DAAE5428F5C7C2000CB45C /* ArtItemViewController.swift */,
-				10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */,
-				10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewCell.swift */,
-				10DAAE5228F5C792000CB45C /* ArtItemCategoryView.swift */,
-				10DAAE5628F5D480000CB45C /* ArtItemCategoryViewCell.swift */,
-				10DAAE5028F539CA000CB45C /* ArtItem.swift */,
+				CB76B9EB28F8EB0400B35811 /* LoginViewController.swift */,
 			);
-			path = ArtItem;
+			path = Login;
+			sourceTree = "<group>";
+		};
+		CB76B9E828F8EADD00B35811 /* SignUp */ = {
+			isa = PBXGroup;
+			children = (
+				CB76B9E928F8EAF700B35811 /* SignUpViewController.swift */,
+			);
+			path = SignUp;
 			sourceTree = "<group>";
 		};
 		CB81DA5528F1B143005164FA /* Message */ = {
@@ -232,6 +266,7 @@
 			children = (
 				CBADEE2C28EEBCE00010B5AA /* Vincent */,
 				CBADEE2B28EEBCE00010B5AA /* Products */,
+				CBF5ED3028F8F27D00580F77 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -256,6 +291,8 @@
 		CBADEE4128EEBD3A0010B5AA /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				CB76B9E828F8EADD00B35811 /* SignUp */,
+				CB76B9E728F8EAD300B35811 /* Login */,
 				7B5CB9D128F7B96B007DDEA2 /* Home */,
 				A91C835328F4E234005DF70F /* ProfileTapped */,
 				7BBA02EF28F450F80006C0B2 /* Category */,
@@ -290,6 +327,8 @@
 			isa = PBXGroup;
 			children = (
 				CBADEE4F28EEBF620010B5AA /* Logger.swift */,
+				CB76B9ED28F8EB7800B35811 /* FirebaseManager.swift */,
+				CB76B9EF28F8EB8C00B35811 /* PushNotificationSender.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -316,6 +355,7 @@
 			children = (
 				CBADEE2D28EEBCE00010B5AA /* AppDelegate.swift */,
 				CBADEE2F28EEBCE00010B5AA /* SceneDelegate.swift */,
+				CBF5ED3F28F8FA0F00580F77 /* GoogleService-Info.plist */,
 				CBADEE3B28EEBCE00010B5AA /* Info.plist */,
 			);
 			path = Supports;
@@ -334,6 +374,7 @@
 				CBADEE6628EEC2E00010B5AA /* Notification+Extension.swift */,
 				5826B99728F2A51000F60693 /* UIFont+Extension.swift */,
 				A951645728F465D3002CD715 /* UITextView+Extension.swift */,
+				CB4DE21528F8EE1E004B23AA /* Sequence+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -391,6 +432,7 @@
 			isa = PBXGroup;
 			children = (
 				CBCBEF8B28F2E454009F134F /* Message */,
+				CB4DE21728F8EF4F004B23AA /* User.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -424,6 +466,13 @@
 			path = Message;
 			sourceTree = "<group>";
 		};
+		CBF5ED3028F8F27D00580F77 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -445,6 +494,12 @@
 				CBADEE7228EEC6720010B5AA /* Then */,
 				CB81DA5328F1B108005164FA /* Lottie */,
 				CBCBEF8D28F2E4A2009F134F /* MessageKit */,
+				CBF5ED3328F8F27D00580F77 /* FirebaseAuth */,
+				CBF5ED3528F8F27D00580F77 /* FirebaseDatabase */,
+				CBF5ED3728F8F27D00580F77 /* FirebaseFirestore */,
+				CBF5ED3928F8F27D00580F77 /* FirebaseMessaging */,
+				CBF5ED3B28F8F27D00580F77 /* FirebaseStorage */,
+				CBF5ED3D28F8F2AC00580F77 /* FirebaseFirestoreSwift */,
 			);
 			productName = Vincent;
 			productReference = CBADEE2A28EEBCE00010B5AA /* Vincent.app */;
@@ -479,6 +534,7 @@
 				CBADEE7128EEC6720010B5AA /* XCRemoteSwiftPackageReference "Then" */,
 				CB81DA5228F1B108005164FA /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				CBCBEF8C28F2E4A2009F134F /* XCRemoteSwiftPackageReference "MessageKit" */,
+				CB4DE20C28F8ED06004B23AA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = CBADEE2B28EEBCE00010B5AA /* Products */;
 			projectDirPath = "";
@@ -496,6 +552,7 @@
 			files = (
 				CBADEE3A28EEBCE00010B5AA /* LaunchScreen.storyboard in Resources */,
 				CBADEE3728EEBCE00010B5AA /* Assets.xcassets in Resources */,
+				CBF5ED4028F8FA0F00580F77 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -510,6 +567,7 @@
 				10DAAE5528F5C7C2000CB45C /* ArtItemViewController.swift in Sources */,
 				CBADEE5F28EEC2490010B5AA /* UICollectionView+Extension.swift in Sources */,
 				CBCBEF8128F2E3B2009F134F /* ImageMediaItem.swift in Sources */,
+				CB4DE21628F8EE1E004B23AA /* Sequence+Extension.swift in Sources */,
 				CBADEE6528EEC28A0010B5AA /* UILabel+Extension.swift in Sources */,
 				CBADEE6D28EEC3AB0010B5AA /* BaseTableViewCell.swift in Sources */,
 				CBADEE5028EEBF620010B5AA /* Logger.swift in Sources */,
@@ -519,6 +577,7 @@
 				58A30EE428F5014A0017C625 /* SellPhotoTapAddBox.swift in Sources */,
 				CBADEE5328EEBF950010B5AA /* ImageLiteral.swift in Sources */,
 				58A30EE228F501140017C625 /* SellPhotoAddedBox.swift in Sources */,
+				CB76B9F028F8EB8C00B35811 /* PushNotificationSender.swift in Sources */,
 				CBADEE5D28EEC2090010B5AA /* UIColor+Extension.swift in Sources */,
 				CBCBEF9028F2E570009F134F /* Sender.swift in Sources */,
 				CBADEE6928EEC3510010B5AA /* UITableView+Extension.swift in Sources */,
@@ -531,10 +590,12 @@
 				A951645828F465D3002CD715 /* UITextView+Extension.swift in Sources */,
 				CBADEE3228EEBCE00010B5AA /* MainViewController.swift in Sources */,
 				CBCBEF8A28F2E430009F134F /* MessageTableViewCell.swift in Sources */,
+				CB76B9EC28F8EB0400B35811 /* LoginViewController.swift in Sources */,
 				CBADEE4E28EEBF060010B5AA /* TabbarViewController.swift in Sources */,
 				7B5CB9D628F7B9C7007DDEA2 /* HomeCategoryCell.swift in Sources */,
 				CBADEE6128EEC25F0010B5AA /* NSObject+Extension.swift in Sources */,
 				A9F068C828F52E36009B5CEE /* ProfileEnumeration.swift in Sources */,
+				CB76B9EE28F8EB7800B35811 /* FirebaseManager.swift in Sources */,
 				10DAAE5728F5D480000CB45C /* ArtItemCategoryViewCell.swift in Sources */,
 				CBADEE6B28EEC39B0010B5AA /* BaseCollectionViewCell.swift in Sources */,
 				A91C835528F4E248005DF70F /* ProfileTappedViewController.swift in Sources */,
@@ -556,7 +617,9 @@
 				10DAAE4D28F539B1000CB45C /* ArtItemCollectionView.swift in Sources */,
 				CBADEE5B28EEC1CA0010B5AA /* UIViewController+Extension.swift in Sources */,
 				A91C835728F4F3FA005DF70F /* ProfileTableViewCell.swift in Sources */,
+				CB76B9EA28F8EAF700B35811 /* SignUpViewController.swift in Sources */,
 				CBADEE3028EEBCE00010B5AA /* SceneDelegate.swift in Sources */,
+				CB4DE21828F8EF4F004B23AA /* User.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -774,6 +837,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		CB4DE20C28F8ED06004B23AA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		CB81DA5228F1B108005164FA /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
@@ -828,6 +899,36 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CBCBEF8C28F2E4A2009F134F /* XCRemoteSwiftPackageReference "MessageKit" */;
 			productName = MessageKit;
+		};
+		CBF5ED3328F8F27D00580F77 /* FirebaseAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CB4DE20C28F8ED06004B23AA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAuth;
+		};
+		CBF5ED3528F8F27D00580F77 /* FirebaseDatabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CB4DE20C28F8ED06004B23AA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDatabase;
+		};
+		CBF5ED3728F8F27D00580F77 /* FirebaseFirestore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CB4DE20C28F8ED06004B23AA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestore;
+		};
+		CBF5ED3928F8F27D00580F77 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CB4DE20C28F8ED06004B23AA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
+		};
+		CBF5ED3B28F8F27D00580F77 /* FirebaseStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CB4DE20C28F8ED06004B23AA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseStorage;
+		};
+		CBF5ED3D28F8F2AC00580F77 /* FirebaseFirestoreSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CB4DE20C28F8ED06004B23AA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestoreSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Vincent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vincent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,93 @@
 {
   "pins" : [
     {
+      "identity" : "abseil-cpp-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "state" : {
+        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
+        "version" : "0.20220203.2"
+      }
+    },
+    {
+      "identity" : "boringssl-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
+      "state" : {
+        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "branch" : "master",
+        "revision" : "6d24463357dd379ab0325e4e612fae4aa0664537"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "e3dd02f390cae79a7073b46dfb0cb6b60c48401b",
+        "version" : "10.0.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "5056b15c5acbb90cd214fe4d6138bdf5a740e5a8",
+        "version" : "9.2.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "68ea347bdb1a69e2d2ae2e25cd085b6ef92f64cb",
+        "version" : "7.9.0"
+      }
+    },
+    {
+      "identity" : "grpc-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-ios.git",
+      "state" : {
+        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
+        "version" : "1.44.3-grpc"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "d4289da23e978f37c344ea6a386e5546e2466294",
+        "version" : "2.1.0"
+      }
+    },
+    {
       "identity" : "inputbaraccessoryview",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nathantannar4/InputBarAccessoryView",
       "state" : {
         "revision" : "0c4431a7f765ecb81dd97615023ff858bf65f89c",
         "version" : "6.1.1"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
+        "version" : "1.22.2"
       }
     },
     {
@@ -28,12 +109,39 @@
       }
     },
     {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "3e4e743631e86c8c70dbc6efdc7beaa6e90fd3bb",
+        "version" : "2.1.1"
+      }
+    },
+    {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SnapKit/SnapKit.git",
       "state" : {
         "revision" : "f222cbdf325885926566172f6f5f06af95473158",
         "version" : "5.6.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
+        "version" : "1.20.2"
       }
     },
     {

--- a/Vincent.xcodeproj/xcuserdata/coby.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Vincent.xcodeproj/xcuserdata/coby.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -4,26 +4,47 @@
 <dict>
 	<key>SchemeUserState</key>
 	<dict>
-		<key>SnapKitPlayground (Playground) 1.xcscheme</key>
+		<key>Promises (Playground) 1.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>5</integer>
 		</dict>
-		<key>SnapKitPlayground (Playground) 2.xcscheme</key>
+		<key>Promises (Playground) 2.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>6</integer>
+		</dict>
+		<key>Promises (Playground).xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
+		<key>SnapKitPlayground (Playground) 1.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
 			<integer>3</integer>
 		</dict>
+		<key>SnapKitPlayground (Playground) 2.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>4</integer>
+		</dict>
 		<key>SnapKitPlayground (Playground).xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>2</integer>
 		</dict>
 		<key>Vincent.xcscheme_^#shared#^_</key>
 		<dict>

--- a/Vincent/Global/Extensions/Sequence+Extension.swift
+++ b/Vincent/Global/Extensions/Sequence+Extension.swift
@@ -1,0 +1,46 @@
+//
+//  Sequence+Extension.swift
+//  Vincent
+//
+//  Created by COBY_PRO on 2022/10/14.
+//
+
+import Foundation
+
+extension Sequence {
+    
+    func asyncMap<T>(
+        _ transform: (Element) async throws -> T
+    ) async rethrows -> [T] {
+        var values = [T]()
+        
+        for element in self {
+            try await values.append(transform(element))
+        }
+        
+        return values
+    }
+    
+    func asyncForEach(
+        _ operation: (Element) async throws -> Void
+    ) async rethrows {
+        for element in self {
+            try await operation(element)
+        }
+    }
+    
+    func concurrentMap<T>(
+        _ transform: @escaping (Element) async throws -> T
+    ) async throws -> [T] {
+        let tasks = map { element in
+            Task {
+                try await transform(element)
+            }
+        }
+        
+        return try await tasks.asyncMap { task in
+            try await task.value
+        }
+    }
+    
+}

--- a/Vincent/Global/Supports/AppDelegate.swift
+++ b/Vincent/Global/Supports/AppDelegate.swift
@@ -7,30 +7,42 @@
 
 import UIKit
 
+import Firebase
+import FirebaseMessaging
+import UserNotifications
+
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
+class AppDelegate: UIResponder, UIApplicationDelegate, MessagingDelegate, UNUserNotificationCenterDelegate {
+    
+    var userToken: String = ""
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        FirebaseApp.configure()
+        
+        Messaging.messaging().delegate = self
+        UNUserNotificationCenter.current().delegate = self
+        
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { success, _ in
+            guard success else {
+                return
+            }
+            
+            print("Success in APNS registry")
+        }
+        
+        application.registerForRemoteNotifications()
+        
         return true
     }
-
-    // MARK: UISceneSession Lifecycle
-
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        messaging.token { token, _ in
+            guard let token = token else {
+                return
+            }
+            self.userToken = token
+            print("Token: \(token)")
+        }
     }
-
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-
 
 }
-

--- a/Vincent/Global/Supports/GoogleService-Info.plist
+++ b/Vincent/Global/Supports/GoogleService-Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>354671414513-tc8ev6rhcbokogm0uibpjld03ot8r4rl.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.354671414513-tc8ev6rhcbokogm0uibpjld03ot8r4rl</string>
+	<key>API_KEY</key>
+	<string>AIzaSyAZeWaphPfVhueACubX6c8621VuKH3XbKQ</string>
+	<key>GCM_SENDER_ID</key>
+	<string>354671414513</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.dime.Vincent</string>
+	<key>PROJECT_ID</key>
+	<string>vincent-c9e69</string>
+	<key>STORAGE_BUCKET</key>
+	<string>vincent-c9e69.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:354671414513:ios:8853e566e5aa080228ad50</string>
+</dict>
+</plist>

--- a/Vincent/Global/Supports/SceneDelegate.swift
+++ b/Vincent/Global/Supports/SceneDelegate.swift
@@ -7,16 +7,19 @@
 
 import UIKit
 
+import FirebaseAuth
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
     
-    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-//        window?.rootViewController = TabbarViewController()
-        window?.rootViewController = ArtItemViewController()
+        
+        let AuthController = UINavigationController(rootViewController: LogInViewController())
+        
+        window?.rootViewController = Auth.auth().currentUser != nil ? TabbarViewController() : AuthController
         window?.makeKeyAndVisible()
     }
     

--- a/Vincent/Global/Utils/FirebaseManager.swift
+++ b/Vincent/Global/Utils/FirebaseManager.swift
@@ -40,7 +40,6 @@ final class FirebaseManager {
     }
     
     func deleteAccount() async {
-        guard let userId = FirebaseManager.auth.currentUser?.uid else { return }
         do {
             try await FirebaseManager.auth.currentUser?.delete()
         } catch {

--- a/Vincent/Global/Utils/FirebaseManager.swift
+++ b/Vincent/Global/Utils/FirebaseManager.swift
@@ -1,0 +1,74 @@
+//
+//  FirebaseManager.swift
+//  Vincent
+//
+//  Created by COBY_PRO on 2022/10/14.
+//
+import UIKit
+
+import Foundation
+import Firebase
+import FirebaseAuth
+import FirebaseFirestore
+
+final class FirebaseManager {
+    
+    static let shared = FirebaseManager()
+    static let store = Firestore.firestore()
+    static let auth = Auth.auth()
+    
+    private init() { }
+    
+    func signInUser(email: String, password: String) async -> String? {
+        do {
+            let data = try await FirebaseManager.auth.signIn(withEmail: email, password: password)
+            print("Success LogIn")
+            return data.user.uid
+        } catch {
+            print("Failed to LogIn")
+            return nil
+        }
+    }
+    
+    func createNewAccount(email: String, password: String) async {
+        do {
+            try await FirebaseManager.auth.createUser(withEmail: email, password: password)
+            print("Successfully created user")
+        } catch {
+            print("Failed to create user")
+        }
+    }
+    
+    func deleteAccount() async {
+        guard let userId = FirebaseManager.auth.currentUser?.uid else { return }
+        do {
+            try await FirebaseManager.auth.currentUser?.delete()
+        } catch {
+            print("Failed to disconnect friend")
+        }
+    }
+    
+    func storeUserInformation(email: String, name: String) async {
+        guard let uid = FirebaseManager.auth.currentUser?.uid else { return }
+        do {
+            let appDelegate = await UIApplication.shared.delegate as! AppDelegate
+            let userToken = await appDelegate.userToken
+            let userData = ["email": email, "uid": uid, "name": name, "token": userToken]
+        
+            try await FirebaseManager.store.collection("users").document(uid).setData(userData)
+        } catch {
+            print("Store User error")
+        }
+    }
+    
+    func updateUserToken(uid: String) async {
+        do {
+            let appDelegate = await UIApplication.shared.delegate as! AppDelegate
+            let userToken = await appDelegate.userToken
+            try await FirebaseManager.store.collection("users").document(uid).updateData(["token" : userToken])
+            print("Success Update")
+        } catch {
+            print("Update User error")
+        }
+    }
+}

--- a/Vincent/Global/Utils/PushNotificationSender.swift
+++ b/Vincent/Global/Utils/PushNotificationSender.swift
@@ -1,0 +1,37 @@
+//
+//  PushNotificationSender.swift
+//  Vincent
+//
+//  Created by COBY_PRO on 2022/10/14.
+//
+
+import UIKit
+
+class PushNotificationSender {
+    func sendPushNotification(to token: String, title: String, body: String) {
+        let server_key = "AAAAvWyUGFU:APA91bHKwd0IyOHA4v86X-NuBKcOTmpt-N1nOppmN94jMbj_Rcl9UrpwGgjlnZAL4gAI-cI2sQI2CtRyX_Qo5zxgZPdueJlM7KQc5ExshtOOtqKrDHaJOVZjL5u2jfSnOk4Aazna1_n3"
+        let urlString = "https://fcm.googleapis.com/fcm/send"
+        let url = NSURL(string: urlString)!
+        let paramString: [String : Any] = ["to" : token,
+                                           "notification" : ["title" : title, "body" : body],
+                                           "data" : ["user" : "test_id"]
+        ]
+        let request = NSMutableURLRequest(url: url as URL)
+        request.httpMethod = "POST"
+        request.httpBody = try? JSONSerialization.data(withJSONObject:paramString, options: [.prettyPrinted])
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("key=\(server_key)", forHTTPHeaderField: "Authorization")
+        let task =  URLSession.shared.dataTask(with: request as URLRequest)  { (data, response, error) in
+            do {
+                if let jsonData = data {
+                    if let jsonDataDict  = try JSONSerialization.jsonObject(with: jsonData, options: JSONSerialization.ReadingOptions.allowFragments) as? [String: AnyObject] {
+                        NSLog("Received data:\n\(jsonDataDict))")
+                    }
+                }
+            } catch let err as NSError {
+                print(err.debugDescription)
+            }
+        }
+        task.resume()
+    }
+}

--- a/Vincent/Models/User.swift
+++ b/Vincent/Models/User.swift
@@ -1,0 +1,13 @@
+//
+//  User.swift
+//  Vincent
+//
+//  Created by COBY_PRO on 2022/10/14.
+//
+
+import FirebaseFirestoreSwift
+
+struct User: Codable, Identifiable {
+    @DocumentID var id: String?
+    let uid, email, name, token: String
+}

--- a/Vincent/Screens/Login/LoginViewController.swift
+++ b/Vincent/Screens/Login/LoginViewController.swift
@@ -1,0 +1,156 @@
+//
+//  LoginViewController.swift
+//  Vincent
+//
+//  Created by COBY_PRO on 2022/10/14.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class LogInViewController: BaseViewController {
+    
+    private let loginLabel = UILabel().then {
+        $0.textAlignment = .center
+        $0.text = "로그인"
+        $0.font = .systemFont(ofSize: 24, weight: .semibold)
+    }
+    
+    private let emailField = UITextField().then {
+        let attributes = [
+            NSAttributedString.Key.foregroundColor : UIColor.mainBlack,
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .regular)
+        ]
+        
+        $0.backgroundColor = .white
+        $0.attributedPlaceholder = NSAttributedString(string: "Email", attributes: attributes)
+        $0.autocapitalizationType = .none
+        $0.layer.cornerRadius = 12
+        $0.layer.masksToBounds = true
+        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
+        $0.leftViewMode = .always
+        $0.clipsToBounds = false
+        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+    }
+    
+    private let passwordField = UITextField().then {
+        let attributes = [
+            NSAttributedString.Key.foregroundColor : UIColor.mainBlack,
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .regular)
+        ]
+        
+        $0.backgroundColor = .white
+        $0.attributedPlaceholder = NSAttributedString(string: "Password", attributes: attributes)
+        $0.layer.cornerRadius = 12
+        $0.layer.masksToBounds = true
+        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
+        $0.leftViewMode = .always
+        $0.clipsToBounds = false
+        $0.isSecureTextEntry = true
+        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+    }
+    
+    private let logInbutton = UIButton().then {
+        $0.backgroundColor = .mainBlack
+        $0.setTitleColor(.white, for: .normal)
+        $0.setTitle("Log In", for: .normal)
+    }
+        
+    private let signUpButton = UIButton().then {
+        $0.backgroundColor = .mainBlack
+        $0.setTitleColor(.white, for: .normal)
+        $0.setTitle("Sign Up", for: .normal)
+    }
+    
+    private let logInErrorLabel = UILabel().then {
+        $0.textAlignment = .center
+        $0.text = "Failed to Log In"
+        $0.font = .systemFont(ofSize: 24, weight: .semibold)
+        $0.textColor = .mainBlack
+    }
+    
+    override func render() {
+        view.addSubviews(loginLabel, emailField, passwordField, logInbutton, signUpButton, logInErrorLabel)
+        
+        logInbutton.addTarget(self, action: #selector(didTapLogInbutton), for: .touchUpInside)
+        signUpButton.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
+        
+        logInErrorLabel.isHidden = true
+        
+        loginLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).inset(30)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        emailField.snp.makeConstraints {
+            $0.top.equalTo(loginLabel.snp.bottom).offset(50)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+        
+        passwordField.snp.makeConstraints {
+            $0.top.equalTo(emailField.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+        
+        logInbutton.snp.makeConstraints {
+            $0.top.equalTo(passwordField.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+        
+        signUpButton.snp.makeConstraints {
+            $0.top.equalTo(logInbutton.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+        
+        logInErrorLabel.snp.makeConstraints {
+            $0.top.equalTo(signUpButton.snp.bottom).offset(30)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+    }
+    
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        self.navigationItem.leftBarButtonItem = nil
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        emailField.becomeFirstResponder()
+    }
+    
+    @objc private func didTapLogInbutton() {
+        guard let email = emailField.text, !email.isEmpty,
+              let password = passwordField.text, !password.isEmpty else {
+            logInErrorLabel.isHidden = false
+            print("Missing field data")
+            return
+        }
+        
+        Task { [weak self] in
+            guard let userId = await FirebaseManager.shared.signInUser(email: email, password: password) else {
+                self?.logInErrorLabel.isHidden = false
+                return
+            }
+            self?.goHome()
+        }
+    }
+    
+    @objc private func didTapSignUpButton() {
+        let viewController = SignUpViewController()
+        self.navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    private func goHome() {
+        let viewController = MainViewController()
+        let navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.modalPresentationStyle = .fullScreen
+        self.present(navigationController, animated: true, completion: nil)
+    }
+
+}

--- a/Vincent/Screens/Login/LoginViewController.swift
+++ b/Vincent/Screens/Login/LoginViewController.swift
@@ -137,6 +137,7 @@ class LogInViewController: BaseViewController {
                 self?.logInErrorLabel.isHidden = false
                 return
             }
+            await FirebaseManager.shared.updateUserToken(uid: userId)
             self?.goHome()
         }
     }

--- a/Vincent/Screens/SignUp/SignUpViewController.swift
+++ b/Vincent/Screens/SignUp/SignUpViewController.swift
@@ -1,0 +1,135 @@
+//
+//  SignUpViewController.swift
+//  Vincent
+//
+//  Created by COBY_PRO on 2022/10/14.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SignUpViewController: BaseViewController {
+    
+    private let emailField = UITextField().then {
+        let attributes = [
+            NSAttributedString.Key.foregroundColor : UIColor.mainBlack,
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .regular)
+        ]
+        
+        $0.backgroundColor = .white
+        $0.attributedPlaceholder = NSAttributedString(string: "Email", attributes: attributes)
+        $0.autocapitalizationType = .none
+        $0.layer.cornerRadius = 12
+        $0.layer.masksToBounds = true
+        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
+        $0.leftViewMode = .always
+        $0.clipsToBounds = false
+        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+    }
+    
+    private let passwordField = UITextField().then {
+        let attributes = [
+            NSAttributedString.Key.foregroundColor : UIColor.mainBlack,
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .regular)
+        ]
+        
+        $0.backgroundColor = .white
+        $0.attributedPlaceholder = NSAttributedString(string: "Password", attributes: attributes)
+        $0.layer.cornerRadius = 12
+        $0.layer.masksToBounds = true
+        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
+        $0.leftViewMode = .always
+        $0.clipsToBounds = false
+        $0.isSecureTextEntry = true
+        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+    }
+    
+    private let nameField = UITextField().then {
+        let attributes = [
+            NSAttributedString.Key.foregroundColor : UIColor.mainBlack,
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .regular)
+        ]
+        
+        $0.backgroundColor = .white
+        $0.attributedPlaceholder = NSAttributedString(string: "Name", attributes: attributes)
+        $0.autocapitalizationType = .none
+        $0.layer.cornerRadius = 12
+        $0.layer.masksToBounds = true
+        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
+        $0.leftViewMode = .always
+        $0.clipsToBounds = false
+        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+    }
+
+    private let signUpButton = UIButton().then {
+        $0.backgroundColor = .mainBlack
+        $0.setTitleColor(.white, for: .normal)
+        $0.setTitle("Start", for: .normal)
+        $0.layer.cornerRadius = 12
+    }
+
+    override func render() {
+        view.addSubviews(emailField, passwordField, nameField, signUpButton)
+        
+        signUpButton.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
+        
+        emailField.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(30)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+        
+        passwordField.snp.makeConstraints {
+            $0.top.equalTo(emailField.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+        
+        nameField.snp.makeConstraints {
+            $0.top.equalTo(passwordField.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+        
+        signUpButton.snp.makeConstraints {
+            $0.top.equalTo(nameField.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        emailField.becomeFirstResponder()
+    }
+    
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        
+        title = "Sign Up"
+    }
+    
+    @objc private func didTapSignUpButton() {
+        guard let email = emailField.text, !email.isEmpty,
+              let password = passwordField.text, !password.isEmpty,
+              let name = nameField.text, !name.isEmpty else {
+            print("Missing field data")
+            return
+        }
+        
+        Task { [weak self] in
+            await FirebaseManager.shared.createNewAccount(email: email, password: password)
+            await FirebaseManager.shared.storeUserInformation(email: email, name: name)
+            self?.goHome()
+        }
+    }
+    
+    private func goHome() {
+        let homeController = TabbarViewController()
+        homeController.modalPresentationStyle = .fullScreen
+        self.present(homeController, animated: true, completion: nil)
+    }
+    
+}


### PR DESCRIPTION
## 배경
UI 작업이 끝난 후, 서버 연결이 필요한 시기가 왔습니다.
서버는 Firebase로 사용하기로 했습니다.

사용할 Firebase 서비스는 다음과 같습니다.
- Authentication (회원가입/로그인)
- Cloud Firestore (DB 저장)
- Storage (사진 저장)
- Messaging (채팅)

이번 PR에서 동작하는 서비스는
- Authentication
- Cloud Firestore

## 작업 내용 (Content)
- 회원가입/로그인 뷰 추가
- Firebase 라이브러리 설치
- FirebaseManger 파일을 생성 후, 회원가입/로그인 및 사용자 DB 생성 함수 추가
- AppDelegate, SceneDelegate에서 Firebase 서비스를 사용할 수 있도록 수정
- Model/User.swift 파일 생성 및 User 모델 추가
- 추후 async/await의 원활한 작업을 위해, Sequence+Extension 추가
- 추후 푸쉬알람 서비스 사용을 위해, Utils/PushNotificationSender 추가
- 추후 푸쉬알람 서비스 사용을 위해, 알람 권한 추가

## 스크린샷
- 로그인/회원가입 화면
<p align="left">
  <img width="250" src="https://user-images.githubusercontent.com/57849386/195753066-ac54a6d0-7533-429a-bcfc-5fb63d20c97a.png">
  <img width="250" src="https://user-images.githubusercontent.com/57849386/195753071-67aa772e-3d07-433a-bb3e-ad071abe3efe.png">
</p>

- 로그인/회원가입을 하면, Firebase 계정과 사용자 DB가 추가됩니다.
<p align="left">
  <img width="500" src="https://user-images.githubusercontent.com/57849386/195753225-a175e4f5-1cc9-4602-9dff-8a3eab8fcafb.png">
  <img width="500" src="https://user-images.githubusercontent.com/57849386/195753204-35c7913d-6f8a-499d-bc22-700457aa2dac.png">
</p>

## 테스트방법
- 앱 실행 후, 회원가입과 로그인을 직접 해보세요.
- 로그아웃 버튼을 뷰에 넣지 않아서, 한 번 로그인 하면, 로그인 화면으로 돌아올 수 없습니다.
- 재 로그인/회원가입을 하시려면, 시뮬레이터를 초기화 해주세요.

## PR & Issues
- #38

## 참고문서, 레퍼런스
- 작업을 하면서 참고한 문서 및 레퍼런스를 작성합니다.
