### PR TITLE
💄 SearchedView에서 카테고리를 눌렀을 때 올라오는 하프모달뷰의 기초 디자인을 했습니다.

### DIFF
--- a/Vincent.xcodeproj/project.pbxproj
+++ b/Vincent.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		106D227328FA56FF009A28B8 /* ArtItemSearchedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106D227228FA56FF009A28B8 /* ArtItemSearchedViewController.swift */; };
 		10C6715328F8199E00100D63 /* ArtItemCategoryModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C6715228F8199E00100D63 /* ArtItemCategoryModalViewController.swift */; };
 		10C6715528F81A6100100D63 /* ArtItemCategoryModalViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C6715428F81A6100100D63 /* ArtItemCategoryModalViewCell.swift */; };
 		10DAAE4D28F539B1000CB45C /* ArtItemCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */; };
@@ -69,6 +70,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		106D227228FA56FF009A28B8 /* ArtItemSearchedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemSearchedViewController.swift; sourceTree = "<group>"; };
 		10C6715228F8199E00100D63 /* ArtItemCategoryModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCategoryModalViewController.swift; sourceTree = "<group>"; };
 		10C6715428F81A6100100D63 /* ArtItemCategoryModalViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCategoryModalViewCell.swift; sourceTree = "<group>"; };
 		10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionView.swift; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				10DAAE5028F539CA000CB45C /* ArtItem.swift */,
 				10C6715228F8199E00100D63 /* ArtItemCategoryModalViewController.swift */,
 				10C6715428F81A6100100D63 /* ArtItemCategoryModalViewCell.swift */,
+				106D227228FA56FF009A28B8 /* ArtItemSearchedViewController.swift */,
 			);
 			path = ArtItem;
 			sourceTree = "<group>";
@@ -556,6 +559,7 @@
 				10DAAE4D28F539B1000CB45C /* ArtItemCollectionView.swift in Sources */,
 				CBADEE5B28EEC1CA0010B5AA /* UIViewController+Extension.swift in Sources */,
 				A91C835728F4F3FA005DF70F /* ProfileTableViewCell.swift in Sources */,
+				106D227328FA56FF009A28B8 /* ArtItemSearchedViewController.swift in Sources */,
 				CBADEE3028EEBCE00010B5AA /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Vincent.xcodeproj/project.pbxproj
+++ b/Vincent.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		10C6715328F8199E00100D63 /* ArtItemCategoryModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C6715228F8199E00100D63 /* ArtItemCategoryModalViewController.swift */; };
+		10C6715528F81A6100100D63 /* ArtItemCategoryModalViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C6715428F81A6100100D63 /* ArtItemCategoryModalViewCell.swift */; };
+		10DAAE4D28F539B1000CB45C /* ArtItemCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */; };
+		10DAAE4F28F539C1000CB45C /* ArtItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewCell.swift */; };
+		10DAAE5128F539CA000CB45C /* ArtItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5028F539CA000CB45C /* ArtItem.swift */; };
+		10DAAE5328F5C792000CB45C /* ArtItemCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5228F5C792000CB45C /* ArtItemCategoryView.swift */; };
+		10DAAE5528F5C7C2000CB45C /* ArtItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5428F5C7C2000CB45C /* ArtItemViewController.swift */; };
+		10DAAE5728F5D480000CB45C /* ArtItemCategoryViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5628F5D480000CB45C /* ArtItemCategoryViewCell.swift */; };
 		58161E9328F43DF0001F8461 /* SellCheckBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58161E9228F43DF0001F8461 /* SellCheckBoxView.swift */; };
 		5826B99828F2A51000F60693 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5826B99728F2A51000F60693 /* UIFont+Extension.swift */; };
 		5855709828F2AEDF002FB7C9 /* SellTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5855709728F2AEDF002FB7C9 /* SellTextFieldView.swift */; };
@@ -24,17 +32,6 @@
 		A9D7B9DE28F27B4D00ECEF58 /* ItemTappedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D7B9DD28F27B4D00ECEF58 /* ItemTappedViewController.swift */; };
 		A9F068C828F52E36009B5CEE /* ProfileEnumeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F068C728F52E36009B5CEE /* ProfileEnumeration.swift */; };
 		CB18F2D928F67D5400742C30 /* GoodInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB18F2D828F67D5400742C30 /* GoodInfoView.swift */; };
-
-
-		10DAAE4D28F539B1000CB45C /* ArtItemCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4C28F539B1000CB45C /* ArtItemCollectionViewController.swift */; };
-		10DAAE4F28F539C1000CB45C /* ArtItemCollectionViewcellController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewcellController.swift */; };
-		10DAAE4D28F539B1000CB45C /* ArtItemCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */; };
-		10DAAE4F28F539C1000CB45C /* ArtItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewCell.swift */; };
-		10DAAE5128F539CA000CB45C /* ArtItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5028F539CA000CB45C /* ArtItem.swift */; };
-		10DAAE5328F5C792000CB45C /* ArtItemCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5228F5C792000CB45C /* ArtItemCategoryView.swift */; };
-		10DAAE5528F5C7C2000CB45C /* ArtItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5428F5C7C2000CB45C /* ArtItemViewController.swift */; };
-		10DAAE5728F5D480000CB45C /* ArtItemCategoryViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DAAE5628F5D480000CB45C /* ArtItemCategoryViewCell.swift */; };
-
 		CB81DA5428F1B108005164FA /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = CB81DA5328F1B108005164FA /* Lottie */; };
 		CB81DA5728F1B15D005164FA /* MessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB81DA5628F1B15D005164FA /* MessageViewController.swift */; };
 		CB81DA5A28F1B19E005164FA /* SellViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB81DA5928F1B19E005164FA /* SellViewController.swift */; };
@@ -72,6 +69,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		10C6715228F8199E00100D63 /* ArtItemCategoryModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCategoryModalViewController.swift; sourceTree = "<group>"; };
+		10C6715428F81A6100100D63 /* ArtItemCategoryModalViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCategoryModalViewCell.swift; sourceTree = "<group>"; };
+		10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionView.swift; sourceTree = "<group>"; };
+		10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionViewCell.swift; sourceTree = "<group>"; };
+		10DAAE5028F539CA000CB45C /* ArtItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItem.swift; sourceTree = "<group>"; };
+		10DAAE5228F5C792000CB45C /* ArtItemCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCategoryView.swift; sourceTree = "<group>"; };
+		10DAAE5428F5C7C2000CB45C /* ArtItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemViewController.swift; sourceTree = "<group>"; };
+		10DAAE5628F5D480000CB45C /* ArtItemCategoryViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCategoryViewCell.swift; sourceTree = "<group>"; };
 		58161E9228F43DF0001F8461 /* SellCheckBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellCheckBoxView.swift; sourceTree = "<group>"; };
 		5826B99728F2A51000F60693 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		5855709728F2AEDF002FB7C9 /* SellTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellTextFieldView.swift; sourceTree = "<group>"; };
@@ -89,15 +94,6 @@
 		A9D7B9DD28F27B4D00ECEF58 /* ItemTappedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemTappedViewController.swift; sourceTree = "<group>"; };
 		A9F068C728F52E36009B5CEE /* ProfileEnumeration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEnumeration.swift; sourceTree = "<group>"; };
 		CB18F2D828F67D5400742C30 /* GoodInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoodInfoView.swift; sourceTree = "<group>"; };
-
-		10DAAE4C28F539B1000CB45C /* ArtItemCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionViewController.swift; sourceTree = "<group>"; };
-		10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewcellController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionViewcellController.swift; sourceTree = "<group>"; };
-		10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionView.swift; sourceTree = "<group>"; };
-		10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCollectionViewCell.swift; sourceTree = "<group>"; };
-		10DAAE5028F539CA000CB45C /* ArtItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItem.swift; sourceTree = "<group>"; };
-		10DAAE5228F5C792000CB45C /* ArtItemCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCategoryView.swift; sourceTree = "<group>"; };
-		10DAAE5428F5C7C2000CB45C /* ArtItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemViewController.swift; sourceTree = "<group>"; };
-		10DAAE5628F5D480000CB45C /* ArtItemCategoryViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtItemCategoryViewCell.swift; sourceTree = "<group>"; };
 		CB81DA5628F1B15D005164FA /* MessageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageViewController.swift; sourceTree = "<group>"; };
 		CB81DA5928F1B19E005164FA /* SellViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellViewController.swift; sourceTree = "<group>"; };
 		CBADEE2A28EEBCE00010B5AA /* Vincent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Vincent.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -147,6 +143,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		10DAAE4B28F5393C000CB45C /* ArtItem */ = {
+			isa = PBXGroup;
+			children = (
+				10DAAE5428F5C7C2000CB45C /* ArtItemViewController.swift */,
+				10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */,
+				10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewCell.swift */,
+				10DAAE5228F5C792000CB45C /* ArtItemCategoryView.swift */,
+				10DAAE5628F5D480000CB45C /* ArtItemCategoryViewCell.swift */,
+				10DAAE5028F539CA000CB45C /* ArtItem.swift */,
+				10C6715228F8199E00100D63 /* ArtItemCategoryModalViewController.swift */,
+				10C6715428F81A6100100D63 /* ArtItemCategoryModalViewCell.swift */,
+			);
+			path = ArtItem;
+			sourceTree = "<group>";
+		};
 		7B5CB9D128F7B96B007DDEA2 /* Home */ = {
 			isa = PBXGroup;
 			children = (
@@ -190,19 +201,6 @@
 				CB18F2D828F67D5400742C30 /* GoodInfoView.swift */,
 			);
 			path = UIComponent;
-			sourceTree = "<group>";
-		};
-		10DAAE4B28F5393C000CB45C /* ArtItem */ = {
-			isa = PBXGroup;
-			children = (
-				10DAAE5428F5C7C2000CB45C /* ArtItemViewController.swift */,
-				10DAAE4C28F539B1000CB45C /* ArtItemCollectionView.swift */,
-				10DAAE4E28F539C1000CB45C /* ArtItemCollectionViewCell.swift */,
-				10DAAE5228F5C792000CB45C /* ArtItemCategoryView.swift */,
-				10DAAE5628F5D480000CB45C /* ArtItemCategoryViewCell.swift */,
-				10DAAE5028F539CA000CB45C /* ArtItem.swift */,
-			);
-			path = ArtItem;
 			sourceTree = "<group>";
 		};
 		CB81DA5528F1B143005164FA /* Message */ = {
@@ -537,9 +535,11 @@
 				A9F068C828F52E36009B5CEE /* ProfileEnumeration.swift in Sources */,
 				10DAAE5728F5D480000CB45C /* ArtItemCategoryViewCell.swift in Sources */,
 				CBADEE6B28EEC39B0010B5AA /* BaseCollectionViewCell.swift in Sources */,
+				10C6715328F8199E00100D63 /* ArtItemCategoryModalViewController.swift in Sources */,
 				A91C835528F4E248005DF70F /* ProfileTappedViewController.swift in Sources */,
 				CBCBEF7D28F2E39B009F134F /* Channel.swift in Sources */,
 				A9D7B9DE28F27B4D00ECEF58 /* ItemTappedViewController.swift in Sources */,
+				10C6715528F81A6100100D63 /* ArtItemCategoryModalViewCell.swift in Sources */,
 				CBADEE6328EEC26F0010B5AA /* UIView+Extension.swift in Sources */,
 				10DAAE5128F539CA000CB45C /* ArtItem.swift in Sources */,
 				CB81DA5A28F1B19E005164FA /* SellViewController.swift in Sources */,

--- a/Vincent/Global/Supports/SceneDelegate.swift
+++ b/Vincent/Global/Supports/SceneDelegate.swift
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
 //        window?.rootViewController = TabbarViewController()
-        window?.rootViewController = ArtItemViewController()
+        window?.rootViewController = ArtItemSearchedViewController()
         window?.makeKeyAndVisible()
     }
     

--- a/Vincent/Global/Supports/SceneDelegate.swift
+++ b/Vincent/Global/Supports/SceneDelegate.swift
@@ -15,8 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-//        window?.rootViewController = TabbarViewController()
-        window?.rootViewController = ArtItemSearchedViewController()
+        window?.rootViewController = TabbarViewController()
         window?.makeKeyAndVisible()
     }
     

--- a/Vincent/Screens/ArtItem/ArtItemCategoryModalViewCell.swift
+++ b/Vincent/Screens/ArtItem/ArtItemCategoryModalViewCell.swift
@@ -11,23 +11,10 @@ import SnapKit
 import Then
 
 final class ArtItemCategoryModalViewCell: BaseCollectionViewCell {
-    
-    private enum Constants {
-        // MARK: contentView layout constants
-        static let contentViewCornerRadius: CGFloat = 4.0
-
-        // MARK: profileImageView layout constants
-        static let imageHeight: CGFloat = 180.0
-
-        // MARK: Generic layout constants
-        static let verticalSpacing: CGFloat = 8.0
-        static let horizontalPadding: CGFloat = 16.0
-        static let profileDescriptionVerticalPadding: CGFloat = 10.0
-    }
 
     let artCategoryModalLabel = UILabel().then {
+        $0.font = .preferredFont(forTextStyle: .headline, weight: .semibold)
         $0.textAlignment = .center
-        $0.layer.cornerRadius = 10
         $0.backgroundColor = .clear
         $0.textColor = .black
     }
@@ -43,10 +30,37 @@ final class ArtItemCategoryModalViewCell: BaseCollectionViewCell {
     }
 
     override func render() {
-        
+        contentView.clipsToBounds = true
+        contentView.layer.borderColor = UIColor.gray.cgColor
+        contentView.layer.borderWidth = 1
+        contentView.layer.cornerRadius = 10
+        contentView.backgroundColor = .clear
+        contentView.addSubview(artCategoryModalLabel)
     }
 
     override func configUI() {
+        artCategoryModalLabel.snp.makeConstraints {
+            $0.centerX.equalTo(contentView.snp.centerX)
+            $0.centerY.equalTo(contentView.snp.centerY)
+        }
+    }
 
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                contentView.backgroundColor = .mainBlack
+                self.artCategoryModalLabel.textColor = .white
+            } else {
+                contentView.backgroundColor = .clear
+                self.artCategoryModalLabel.textColor = .black
+            }
+        }
     }
 }
+
+extension ArtItemCategoryModalViewCell: ReusableView {
+    static var identifier: String {
+        return String(describing: self)
+    }
+}
+

--- a/Vincent/Screens/ArtItem/ArtItemCategoryModalViewCell.swift
+++ b/Vincent/Screens/ArtItem/ArtItemCategoryModalViewCell.swift
@@ -1,0 +1,52 @@
+//
+//  ArtItemCategoryModalViewCell.swift
+//  Vincent
+//
+//  Created by 김연호 on 2022/10/13.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ArtItemCategoryModalViewCell: BaseCollectionViewCell {
+    
+    private enum Constants {
+        // MARK: contentView layout constants
+        static let contentViewCornerRadius: CGFloat = 4.0
+
+        // MARK: profileImageView layout constants
+        static let imageHeight: CGFloat = 180.0
+
+        // MARK: Generic layout constants
+        static let verticalSpacing: CGFloat = 8.0
+        static let horizontalPadding: CGFloat = 16.0
+        static let profileDescriptionVerticalPadding: CGFloat = 10.0
+    }
+
+    let artCategoryModalLabel = UILabel().then {
+        $0.textAlignment = .center
+        $0.layer.cornerRadius = 10
+        $0.backgroundColor = .clear
+        $0.textColor = .black
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+        configUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func render() {
+        
+    }
+
+    override func configUI() {
+
+    }
+}

--- a/Vincent/Screens/ArtItem/ArtItemCategoryModalViewController.swift
+++ b/Vincent/Screens/ArtItem/ArtItemCategoryModalViewController.swift
@@ -1,0 +1,16 @@
+//
+//  ArtItemCategoryModalViewController.swift
+//  Vincent
+//
+//  Created by 김연호 on 2022/10/13.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+
+final class ArtItemCategotyModalViewController(): BaseViewController {
+    
+}

--- a/Vincent/Screens/ArtItem/ArtItemCategoryModalViewController.swift
+++ b/Vincent/Screens/ArtItem/ArtItemCategoryModalViewController.swift
@@ -11,6 +11,124 @@ import SnapKit
 import Then
 
 
-final class ArtItemCategotyModalViewController(): BaseViewController {
-    
+final class ArtItemCategotyModalViewController: BaseViewController {
+
+    private enum LayoutConstant {
+        static let spacing: CGFloat = 10.0
+        static let cellWidth: CGFloat = 90
+        static let cellHeight: CGFloat = 40
+    }
+
+    private let categoryDate = ["카테고리1", "카테고리2","카테고리3","카테고리4","카테고리5","카테고리6","카테고리7","카테고리8","카테고리9"]
+
+    private let modalViewTitle = UILabel().then {
+        $0.text = "카테고리"
+        $0.font = .preferredFont(forTextStyle: .callout, weight: .bold)
+    }
+
+    private let refreshButton = UIButton().then {
+        $0.imageView?.contentMode = .scaleAspectFit
+        $0.imageEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        $0.backgroundColor = .red
+        $0.tintColor = .mainBlack
+        $0.addTarget(self, action: #selector(refreshbuttonAction(_:)), for: .touchUpInside)
+        $0.setImage(UIImage(systemName: "arrow.clockwise.circle.fill"), for: .normal)
+    }
+
+    private let acceptCategoryButton = UIButton().then {
+        $0.setTitleColor(.mainBlack, for: .normal)
+        $0.setTitle("적용하기", for: .normal)
+        $0.layer.cornerRadius = 10
+        $0.titleLabel?.font = .preferredFont(forTextStyle: .title2, weight: .bold)
+        $0.backgroundColor = .mainYellow
+        $0.addTarget(self, action: #selector(acceptbuttonAction(_:)), for: .touchUpInside)
+        $0.backgroundColor = .mainYellow
+    }
+    private let collectionViewFlowLayout = UICollectionViewFlowLayout().then {
+        $0.sectionInset = UIEdgeInsets(top: LayoutConstant.spacing, left: LayoutConstant.spacing, bottom: LayoutConstant.spacing, right: LayoutConstant.spacing)
+        $0.itemSize = CGSize(width: LayoutConstant.cellWidth, height: LayoutConstant.cellHeight)
+        $0.minimumLineSpacing = 8
+    }
+    private lazy var categoryDetailCollectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout).then {
+        $0.register(ArtItemCategoryModalViewCell.self, forCellWithReuseIdentifier: ArtItemCategoryModalViewCell.identifier)
+        $0.dataSource = self
+        $0.delegate = self
+        $0.backgroundColor = .clear
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        render()
+        configUI()
+    }
+
+    override func render() {
+        view.addSubview(categoryDetailCollectionView)
+        view.addSubviews(modalViewTitle, refreshButton, acceptCategoryButton)
+        view.backgroundColor = .white
+    }
+
+    override func configUI() {
+        modalViewTitle.snp.makeConstraints {
+            $0.top.equalTo(view.snp.top).offset(20)
+            $0.leading.equalTo(view.snp.leading).offset(40)
+        }
+
+        categoryDetailCollectionView.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(30)
+            $0.trailing.equalToSuperview().inset(30)
+            $0.top.equalTo(modalViewTitle.snp.bottom).offset(20)
+            $0.height.equalTo(150)
+        }
+
+        refreshButton.snp.makeConstraints {
+            $0.leading.equalTo(view.snp.leading).offset(60)
+            $0.top.equalTo(categoryDetailCollectionView.snp.bottom).offset(60)
+            $0.width.equalTo(55)
+            $0.height.equalTo(55)
+        }
+
+        acceptCategoryButton.snp.makeConstraints {
+            $0.trailing.equalTo(view.snp.trailing).inset(40)
+            $0.top.equalTo(categoryDetailCollectionView.snp.bottom).offset(60)
+            $0.width.equalTo(200)
+            $0.height.equalTo(55)
+        }
+    }
+
+}
+
+extension ArtItemCategotyModalViewController {
+
+    @objc private func refreshbuttonAction(_: UIButton!) {
+        print("refresh!")
+    }
+
+    @objc private func acceptbuttonAction(_: UIButton!) {
+        print("accept!")
+    }
+}
+
+extension ArtItemCategotyModalViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return categoryDate.count
+    }
+
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ArtItemCategoryModalViewCell.identifier, for: indexPath) as? ArtItemCategoryModalViewCell else {
+            assert(false, "Wrong cell") }
+
+        cell.artCategoryModalLabel.text = categoryDate[indexPath.item]
+        cell.contentView.backgroundColor = .clear
+      
+        return cell
+    }
+
+}
+
+extension ArtItemCategotyModalViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: LayoutConstant.cellWidth, height: LayoutConstant.cellHeight)
+    }
 }

--- a/Vincent/Screens/ArtItem/ArtItemCategoryModalViewController.swift
+++ b/Vincent/Screens/ArtItem/ArtItemCategoryModalViewController.swift
@@ -26,13 +26,15 @@ final class ArtItemCategotyModalViewController: BaseViewController {
         $0.font = .preferredFont(forTextStyle: .callout, weight: .bold)
     }
 
-    private let refreshButton = UIButton().then {
+    private let refreshConfiguration = UIImage.SymbolConfiguration(textStyle: .largeTitle)
+
+    private lazy var refreshButton = UIButton().then {
         $0.imageView?.contentMode = .scaleAspectFit
         $0.imageEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
         $0.backgroundColor = .red
         $0.tintColor = .mainBlack
         $0.addTarget(self, action: #selector(refreshbuttonAction(_:)), for: .touchUpInside)
-        $0.setImage(UIImage(systemName: "arrow.clockwise.circle.fill"), for: .normal)
+        $0.setImage(UIImage(systemName: "arrow.clockwise.circle.fill", withConfiguration: refreshConfiguration), for: .normal)
     }
 
     private let acceptCategoryButton = UIButton().then {

--- a/Vincent/Screens/ArtItem/ArtItemCategoryViewCell.swift
+++ b/Vincent/Screens/ArtItem/ArtItemCategoryViewCell.swift
@@ -41,7 +41,6 @@ final class ArtItemCategoryCell: UICollectionViewCell {
     }
 
     private func setupLayouts() {
-
         artItemCategoryLabel.snp.makeConstraints {
             $0.centerX.equalTo(contentView.snp.centerX)
             $0.centerY.equalTo(contentView.snp.centerY)

--- a/Vincent/Screens/ArtItem/ArtItemSearchedViewController.swift
+++ b/Vincent/Screens/ArtItem/ArtItemSearchedViewController.swift
@@ -1,8 +1,8 @@
 //
-//  ArtItemViewController.swift
+//  ArtItemSearchedView.swift
 //  Vincent
 //
-//  Created by 김연호 on 2022/10/12.
+//  Created by 김연호 on 2022/10/15.
 //
 
 import UIKit
@@ -10,8 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-    // TODO:
-class ArtItemViewController: BaseViewController {
+class ArtItemSearchedViewController: BaseViewController {
 
     private let searchView = UIView().then {
         $0.backgroundColor = .black
@@ -29,32 +28,28 @@ class ArtItemViewController: BaseViewController {
         $0.placeholder = "윈저앤뉴튼, 홀베인, 클레이트 등"
     }
 
-    private let artItemCount = UILabel().then {
-        $0.backgroundColor = .black
-        $0.font = .systemFont(ofSize: 16, weight: .medium)
-        $0.text = "상품00개"
+    // TODO: -Dropdown 라이브러리 다운받아서 드롭다운으로 만들어야 할 것 같습니다. 임시로 디자인만 넣어놓음
+    private let categoryMenu = UIButton().then {
+        $0.addTarget(self, action: #selector(presentModal(_:)), for: .primaryActionTriggered)
+        $0.backgroundColor = .mainBlack
+        $0.titleLabel?.textColor = .white
+        $0.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout, weight: .semibold)
     }
-
-    private let artItemCategoryListView = ArtItemCategoryView()
 
     private let artItemCollectionView = ArtItemCollectionView()
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupViews()
-        setupLayouts()
+        render()
+        configUI()
     }
 
-    private func setupViews() {
-        view.backgroundColor = .white
-
-        view.addSubviews(searchView, magniImage, searchTextField, artItemCount)
-        view.addSubview(artItemCategoryListView)
+    override func render() {
+        view.addSubviews(searchView, magniImage, searchTextField, categoryMenu)
         view.addSubview(artItemCollectionView)
     }
 
-    private func setupLayouts() {
-
+    override func configUI() {
         searchView.snp.makeConstraints {
             $0.leading.equalTo(view.snp.leading).offset(60)
             $0.trailing.equalTo(view.snp.trailing).inset(20)
@@ -74,22 +69,36 @@ class ArtItemViewController: BaseViewController {
             $0.bottom.equalTo(searchView.snp.bottom).inset(7)
         }
 
-        artItemCount.snp.makeConstraints {
+        categoryMenu.snp.makeConstraints {
             $0.leading.equalTo(view.snp.leading).offset(20)
-            $0.top.equalTo(artItemCategoryListView.snp.bottom).offset(30)
-        }
-
-        artItemCategoryListView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
-            $0.top.equalTo(searchView.snp.bottom).offset(40)
-            $0.height.equalTo(190)
+            $0.top.equalTo(searchView.snp.bottom).offset(30)
         }
 
         artItemCollectionView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
-            $0.top.equalTo(artItemCategoryListView.snp.bottom).offset(30)
+            $0.top.equalTo(categoryMenu.snp.bottom).offset(30)
             $0.bottom.equalTo(view.snp.bottom)
         }
+    }
+}
+
+extension ArtItemSearchedViewController {
+    @objc private func presentModal(_: UIButton!) {
+        let categoryModalView = ArtItemCategotyModalViewController()
+
+        if #available(iOS 15.0, *) {
+            if let sheet = categoryModalView.sheetPresentationController {
+                sheet.detents = [.medium()]
+                sheet.preferredCornerRadius = 30
+                sheet.prefersGrabberVisible = true
+                sheet.prefersScrollingExpandsWhenScrolledToEdge = false
+                sheet.selectedDetentIdentifier = .medium
+            }
+        } else {
+            // Fallback on earlier versions
+        }
+
+        present(categoryModalView, animated: true, completion: nil)
 
     }
 }


### PR DESCRIPTION
## 배경
- 검색해서 나오는 물품의 카테고리 뷰에서 카테고리를 고를 수 있는 상세 하프모달뷰입니다.

## 작업 내용 (Content)
- 피그마상에 SearchedView로 되어있는 화면의 ViewController와 HalfModalViewController, CollectionView를 통한 카테고리 뷰
등의 파일을 3개를 추가하였습니다.

- 하단의 refresh버튼과 적용하기 버튼은 버튼이벤트로 현재 print값이 출력되는 것을 확인하였습니다.

- refresh 버튼, UIButton 내부에 들어가는 이미지의 크기를 더 키워야하는데 다른 분들의 조언을 듣고싶습니다.

- 현재 HalfModal로 구현한 상태라 피그마에서 구현 된 이미지와는 모달의 크기도 살짝 더 크고 하단의 버튼들 아래의 여백이 더 많이 남습니다. 지금은 어떻게 해결할 지 감이 안잡히는 상태입니다.

## 스크린샷
- 화면 전환이나 인터렉션이 있는 경우엔 GIF, 정적인 화면이라면 스크린샷을 이용합니다.

<p align="left">
  <img width="300" alt="스크린샷1" src="https://user-images.githubusercontent.com/81131715/195994050-48ced74c-ac55-4f27-a18e-3f8fe0d1bbd1.gif">
<img width="300" alt="스크린샷1" src="https://user-images.githubusercontent.com/81131715/195994253-9ba6a905-d40d-47b3-85c3-b6ab62552199.png">
</p>


## 테스트방법
-  window?.rootViewController = ArtItemSearchedViewController() 로 변경 후 좌측에 회색의 네모 무언가를 클릭하면 모달창이 뜹니다.

-  window?.rootViewController = ArtItemCategoryModalViewController() 로 하면 모달만 구현한 뷰컨이 나옵니다.

## PR & Issues
- 

## 참고문서, 레퍼런스
- 작업을 하면서 참고한 문서 및 레퍼런스를 작성합니다.
